### PR TITLE
Add possibility to filter for licenses

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import argparse
+import xml.etree.ElementTree as ET
+import validator
+from const import *
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-f", "--file", dest="filepath", required=True,
+                    help="path to xml file", metavar="FILE",
+                    type=lambda x: validator.is_valid_file(parser, x))
+args = parser.parse_args()
+
+def get_all_licenses():
+    licenses = set()
+    for event, elem in ET.iterparse(args.filepath):
+        if event == 'end' and elem.tag == '{}rightsResource'.format(namespace_prefix):
+            l = elem.find('.//lido:term', namespaces).text
+            licenses.add(l)
+    return licenses
+
+for l in get_all_licenses():
+    print(l)
+
+

--- a/const.py
+++ b/const.py
@@ -1,0 +1,3 @@
+schema_uri       = 'http://www.lido-schema.org'
+namespace_prefix = '{' + schema_uri + '}'
+namespaces       = {'lido': schema_uri}

--- a/filter.py
+++ b/filter.py
@@ -1,0 +1,30 @@
+from const import *
+
+def has_term(elem, term):
+    term_elements = elem.findall('.//lido:classificationWrap//lido:term', namespaces)
+    term_texts    = map(lambda x: x.text, term_elements)
+
+    if term is None:
+        return True
+
+    if term in term_texts:
+        return True
+
+    return False
+
+def has_license(elem, license):
+    if license is None:
+        return True
+
+    subitem_license = elem.find('.//lido:rightsResource//lido:term', namespaces)
+
+    # subitem of item has no license (so probably no image either)
+    if subitem_license is None:
+        return False
+
+    subitem_license_text = subitem_license.text
+
+    if license == subitem_license_text:
+        return True
+
+    return False

--- a/item.py
+++ b/item.py
@@ -1,5 +1,4 @@
-baseurl = "https://sammlungonline.mkg-hamburg.de/resource-cache/mkg/1/"
-
+#baseurl = "https://sammlungonline.mkg-hamburg.de/resource-cache/mkg/1/"
 baseurl = "https://sammlungonline.mkg-hamburg.de/de/object/{}/image_download/0"
 
 class Item:

--- a/main.py
+++ b/main.py
@@ -27,11 +27,10 @@ args = parser.parse_args()
 item_list = []
 
 if args.verbose:
-    print("Downloading all items that have classification term {} to folder {}".format(args.classification, args.outputdir))
-
-
-if args.verbose:
-    print("Filtering items for term: {}".format(args.classification))
+    print("Downloading items")
+    print("classification filter: %s" % args.classification)
+    print("license filter: %s" % args.license)
+    print("output dir: %s" % args.outputdir)
 
 # iterating elements and clearing them after usage
 # -> allows to start handling elements right away and have low memory impact
@@ -61,4 +60,4 @@ for i in item_list:
     urllib.request.urlretrieve(i.uri, filepath)
 
     if args.verbose:
-        print("Downloading: {}".format(filepath))
+        print("Downloading: %s" % filepath)

--- a/main.py
+++ b/main.py
@@ -2,17 +2,17 @@
 import argparse
 import xml.etree.ElementTree as ET
 import urllib.request
-import file_validator
+import validator
 from item import Item
 from const import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", "--file", dest="filepath", required=True,
                     help="path to xml file", metavar="FILE",
-                    type=lambda x: file_validator.is_valid_file(parser, x))
+                    type=lambda x: validator.is_valid_file(parser, x))
 parser.add_argument("-o", "--output_dir", dest="outputdir", required=False,
                     help="folder path for saving the images", default='.',
-                    type=lambda x: file_validator.is_valid_dir(parser, x))
+                    type=lambda x: validator.is_valid_dir(parser, x))
 parser.add_argument("-fc", "--filter_classification_term", dest="classification", required=False,
                     help="pass a classification term to filter by (e.g. 'Fotografie')")
 parser.add_argument("-v", "--verbosity", dest="verbose",

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as ET
 import urllib.request
 import file_validator
 from item import Item
+from const import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f", "--file", dest="filepath", required=True,
@@ -18,10 +19,6 @@ parser.add_argument("-v", "--verbosity", dest="verbose",
                     help="increase output verbosity", action="store_true")
 
 args = parser.parse_args()
-
-schema_uri       = 'http://www.lido-schema.org'
-namespace_prefix = '{' + schema_uri + '}'
-namespaces       = {'lido': schema_uri}
 
 item_list = []
 

--- a/validator.py
+++ b/validator.py
@@ -17,3 +17,13 @@ def is_valid_dir(parser, arg):
         return
 
     return arg + '/'
+
+def is_valid_license(parser, arg):
+    licenses = {'CC-0': 'CC0 1.0', 'CC-BY': 'CC BY 3.0 DE', 'Copyright': 'Rechte vorbehalten - freier Zugang'}
+
+    l = licenses.get(arg, None)
+
+    if l is None:
+        parser.error("Invalid license: {} \n Available licenses: {} ".format(arg, licenses.keys()))
+
+    return l


### PR DESCRIPTION
fixes #2

When a license filter is given, no empty images occur because items without images also don't have license entries for those images.
